### PR TITLE
Sending through server using TCP

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,15 +2,12 @@ package main
 
 import (
 	"flag"
+	"os"
 	"strings"
 
-	"encoding/json"
-
 	"github.com/asticode/go-astilectron"
-	"github.com/asticode/go-astilectron-bootstrap"
-	"github.com/asticode/go-astilog"
-	"github.com/pkg/errors"
 )
+
 const about string = "This is a simple P2P File transferer application that allows users to transfer files at extremely fast speeds using Googles quic protocol!"
 
 // AppInfo given by the front end.
@@ -35,7 +32,18 @@ type MessageOut struct {
 }
 
 func main() {
-	// Init
+
+	peer1 := strings.ToLower(os.Args[1])
+	peer2 := strings.ToLower(os.Args[2])
+	fileName := ""
+	if len(os.Args) == 4 {
+		fileName = os.Args[3]
+	}
+	initTransfer(peer1, peer2, fileName)
+	return
+}
+
+/*// Init
 	flag.Parse()
 	astilog.FlagInit()
 
@@ -127,4 +135,8 @@ func notifyFrontEnd(msg string) {
 		bootstrap.SendMessage(w, "Error", msg, func(m *bootstrap.MessageIn) {
 		})
 	}
+}*/
+
+func notifyFrontEnd(msg string) {
+	return
 }

--- a/main.go
+++ b/main.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
-	"os"
 	"strings"
 
 	"github.com/asticode/go-astilectron"
+	bootstrap "github.com/asticode/go-astilectron-bootstrap"
+	astilog "github.com/asticode/go-astilog"
+	"github.com/pkg/errors"
 )
 
 const about string = "This is a simple P2P File transferer application that allows users to transfer files at extremely fast speeds using Googles quic protocol!"
@@ -32,18 +35,7 @@ type MessageOut struct {
 }
 
 func main() {
-
-	peer1 := strings.ToLower(os.Args[1])
-	peer2 := strings.ToLower(os.Args[2])
-	fileName := ""
-	if len(os.Args) == 4 {
-		fileName = os.Args[3]
-	}
-	initTransfer(peer1, peer2, fileName)
-	return
-}
-
-/*// Init
+	// Init
 	flag.Parse()
 	astilog.FlagInit()
 
@@ -135,8 +127,4 @@ func notifyFrontEnd(msg string) {
 		bootstrap.SendMessage(w, "Error", msg, func(m *bootstrap.MessageIn) {
 		})
 	}
-}*/
-
-func notifyFrontEnd(msg string) {
-	return
 }

--- a/peer.go
+++ b/peer.go
@@ -152,7 +152,7 @@ func receieveFromServer(file *os.File) error {
 
 // receiveFile recieves a file from whoever establishes a quic connection with the udp server.
 func receiveFile(server net.PacketConn, addr string) error {
-	newFile, err := os.Create("/Users/fattouche/Desktop/"+friend.FileName)
+	newFile, err := os.Create(friend.FileName)
 	if err != nil {
 		log.Println("Error: " + err.Error())
 		notifyFrontEnd(err.Error()+"")

--- a/peer.go
+++ b/peer.go
@@ -65,13 +65,14 @@ func holePunch(server *net.UDPConn, addr *net.UDPAddr) error {
 	}
 }
 
-func sendThroughServer(file *os.File, addr string) {
+func sendThroughServer(file *os.File, addr string) error {
 	log.Println("Sending through server")
 	notifyFrontEnd("Couldn't connect directly to peer, sending through server ...")
 	conn, err := net.Dial("tcp", CentServerAddr)
 	if err != nil {
 		log.Println("Couldnt connect to central server")
 		notifyFrontEnd("We are experiencing network problems, try again later.")
+		return err
 	}
 	defer conn.Close()
 	buff, _ := json.Marshal(myPeerInfo)
@@ -82,15 +83,18 @@ func sendThroughServer(file *os.File, addr string) {
 	notifier := fmt.Sprintf("Finished transfer in %f seconds!", time.Since(start).Seconds())
 	log.Println(notifier)
 	notifyFrontEnd(notifier)
+	return nil
 }
 
 // sendFile sends a file from the server to the addr using Google's quic protocol on top of UDP.
-func sendFile(server net.PacketConn, file *os.File, addr string) {
+func sendFile(server net.PacketConn, file *os.File, addr string) error {
 	udpAddr, err := net.ResolveUDPAddr("udp", addr)
 	session, err := quic.Dial(server, udpAddr, addr, &tls.Config{InsecureSkipVerify: true}, nil)
 	if err != nil {
 		log.Println("Error: ", err)
-		sendThroughServer(file, addr)
+		server.Close()
+		err := sendThroughServer(file, addr)
+		return err
 	}
 	defer session.Close(err)
 	stream, err := session.OpenStreamSync()
@@ -105,52 +109,61 @@ func sendFile(server net.PacketConn, file *os.File, addr string) {
 	notifier := fmt.Sprintf("Finished transfer in %f seconds!", time.Since(start).Seconds())
 	log.Println(notifier)
 	notifyFrontEnd(notifier)
+	return nil
 }
 
-func receieveFromServer(file *os.File) {
-	log.Println("Reciving from server")
+func receieveFromServer(file *os.File) error {
 	notifyFrontEnd("Couldn't connect directly to peer, receiving from server ...")
 	conn, err := net.Dial("tcp", CentServerAddr)
 	if err != nil {
 		log.Println("Couldnt connect to central server")
 		notifyFrontEnd("We are experiencing network problems, try again later.")
+		return err
 	}
 	defer conn.Close()
 	buff, _ := json.Marshal(myPeerInfo)
 	conn.Write(buff)
-	log.Println("receiving from server")
+	log.Println("Receiving from server")
 	start := time.Now()
-	io.Copy(file, conn)
+	_, err = io.Copy(file, conn)
+	if err != nil {
+		fmt.Println("Error receiving")
+		return err
+	}
 	notifier := fmt.Sprintf("Finished transfer in %f seconds!", time.Since(start).Seconds())
 	log.Println(notifier)
 	notifyFrontEnd(notifier)
+	return nil
 }
 
 // receiveFile recieves a file from whoever establishes a quic connection with the udp server.
-func receiveFile(server net.PacketConn, addr string) {
+func receiveFile(server net.PacketConn, addr string) error {
 	newFile, err := os.Create(friend.FileName)
 	if err != nil {
 		log.Println("Error: " + err.Error())
+		return err
 	}
 	defer newFile.Close()
 	server.SetReadDeadline(time.Now().Add(time.Second * 5))
 	connection, err := quic.Listen(server, generateTLSConfig(), nil)
 	if err != nil {
 		log.Println("Error: " + err.Error())
+		return err
 	}
 	defer connection.Close()
 	session, err := connection.Accept()
 	if err != nil {
 		log.Println("Error: " + err.Error())
 		server.Close()
-		receieveFromServer(newFile)
-		return
+		err := receieveFromServer(newFile)
+		return err
 	}
 	defer session.Close(err)
 
 	stream, err := session.AcceptStream()
 	if err != nil {
 		log.Println("Error: " + err.Error())
+		return err
 	}
 	defer stream.Close()
 
@@ -163,6 +176,7 @@ func receiveFile(server net.PacketConn, addr string) {
 	notifier := fmt.Sprintf("Finished transfer in %f seconds!", time.Since(start).Seconds())
 	log.Println(notifier)
 	notifyFrontEnd(notifier)
+	return nil
 }
 
 //  generateTLSConfig is used to create a basic tls configuration for quic protocol.
@@ -209,14 +223,13 @@ func transferFile(server *net.UDPConn) error {
 	//If holepunching failed we know there is no peer in our network
 	if myPeerInfo.FileName != "" {
 		if public {
-			sendFile(server, file, friend.PubIP)
+			return sendFile(server, file, friend.PubIP)
 		} else {
-			sendFile(server, file, friend.PrivIP)
+			return sendFile(server, file, friend.PrivIP)
 		}
 	} else {
-		receiveFile(server, myPeerInfo.PrivIP)
+		return receiveFile(server, myPeerInfo.PrivIP)
 	}
-	return nil
 }
 
 // getPeerInfo communicates with the centralized server to exchange information between peers.
@@ -345,7 +358,7 @@ func initTransfer(peer1, peer2, filePath string) {
 	err = transferFile(server)
 	if err != nil {
 		log.Println("Error :" + err.Error())
-		notifyFrontEnd("Couldn't open " + myPeerInfo.FileName)
+		notifyFrontEnd("We are experiencing issues, please try again later")
 		return
 	}
 }

--- a/peer.go
+++ b/peer.go
@@ -68,6 +68,7 @@ func holePunch(server *net.UDPConn, addr *net.UDPAddr) error {
 func sendThroughServer(file *os.File, addr string) error {
 	notifyFrontEnd("Couldn't connect directly to peer, sending through server ...")
 	conn, err := net.Dial("tcp", CentServerAddr)
+	defer conn.Close()
 	if err != nil {
 		log.Println("Couldnt connect to central server")
 		notifyFrontEnd("We are experiencing network problems, try again later.")
@@ -119,6 +120,7 @@ func sendFile(server net.PacketConn, file *os.File, addr string) error {
 func receieveFromServer(file *os.File) error {
 	notifyFrontEnd("Couldn't connect directly to peer, receiving from server ...")
 	conn, err := net.Dial("tcp", CentServerAddr)
+	defer conn.Close()
 	if err != nil {
 		log.Println("Couldnt connect to central server")
 		notifyFrontEnd("We are experiencing network problems, try again later.")
@@ -145,6 +147,7 @@ func receiveFile(server net.PacketConn, addr string) error {
 	newFile, err := os.Create(friend.FileName)
 	if err != nil {
 		log.Println("Error: " + err.Error())
+		notifyFrontEnd(err.Error()+"")
 		return err
 	}
 	defer newFile.Close()
@@ -360,7 +363,7 @@ func initTransfer(peer1, peer2, filePath string) {
 	err = transferFile(server)
 	if err != nil {
 		log.Println("Error :" + err.Error())
-		notifyFrontEnd("We are experiencing issues, please try again later")
+		notifyFrontEnd("We are experiencing issues, please try again later: "+ err.Error())
 		return
 	}
 }

--- a/peer.go
+++ b/peer.go
@@ -74,6 +74,8 @@ func sendThroughServer(file *os.File, addr string) {
 		notifyFrontEnd("We are experiencing network problems, try again later.")
 	}
 	defer conn.Close()
+	buff, _ := json.Marshal(myPeerInfo)
+	conn.Write(buff)
 	log.Println("Sending through server")
 	start := time.Now()
 	io.Copy(conn, file)
@@ -114,6 +116,8 @@ func receieveFromServer(file *os.File) {
 		notifyFrontEnd("We are experiencing network problems, try again later.")
 	}
 	defer conn.Close()
+	buff, _ := json.Marshal(myPeerInfo)
+	conn.Write(buff)
 	log.Println("receiving from server")
 	start := time.Now()
 	io.Copy(file, conn)

--- a/server/server.go
+++ b/server/server.go
@@ -103,9 +103,17 @@ func sendToPeers(conn net.Conn) {
 		fmt.Println("Recieved both tcp connections, copying")
 		conn2 := tcpMap[peer.Friend]
 		if peer.FileName != "" {
-			io.Copy(conn, conn2)
+			conn.Write([]byte("1"))
+			_, err := io.Copy(conn2, conn)
+			if err != nil {
+				fmt.Println("Error: ", err)
+			}
 		} else {
-			io.Copy(conn2, conn)
+			conn2.Write([]byte("1"))
+			_, err := io.Copy(conn, conn2)
+			if err != nil {
+				fmt.Println("Error: ", err)
+			}
 		}
 		fmt.Println("Finished copying!")
 	} else {

--- a/server/server.go
+++ b/server/server.go
@@ -100,15 +100,16 @@ func sendToPeers(conn net.Conn) {
 		fmt.Println("Error: ", err)
 	}
 	if _, ok := tcpMap[peer.Friend]; ok && tcpMap[peer.Friend] != nil {
-		fmt.Println("Recieved connections! Copying!")
+		fmt.Println("Recieved both tcp connections, copying")
 		conn2 := tcpMap[peer.Friend]
 		if peer.FileName != "" {
 			io.Copy(conn, conn2)
 		} else {
 			io.Copy(conn2, conn)
 		}
+		fmt.Println("Finished copying!")
 	} else {
-		fmt.Println("Recieved connection from ", conn.RemoteAddr())
+		fmt.Println("Recieved tcp connection from ", conn.RemoteAddr())
 		tcpMap[peer.Name] = conn
 	}
 }
@@ -143,6 +144,7 @@ func main() {
 
 	buff := make([]byte, 1000)
 	peerMap = make(map[string]*Peer)
+	tcpMap = make(map[string]net.Conn)
 	connection, _ := quic.Listen(server, generateTLSConfig(), nil)
 
 	fmt.Println("Waiting for connections from peers")

--- a/server/server.go
+++ b/server/server.go
@@ -102,6 +102,8 @@ func sendToPeers(conn net.Conn) {
 	if _, ok := tcpMap[peer.Friend]; ok && tcpMap[peer.Friend] != nil {
 		fmt.Println("Recieved both tcp connections, copying")
 		conn2 := tcpMap[peer.Friend]
+		defer conn2.Close()
+		defer conn.Close()
 		if peer.FileName != "" {
 			conn.Write([]byte("1"))
 			_, err := io.Copy(conn2, conn)

--- a/server/server.go
+++ b/server/server.go
@@ -118,6 +118,8 @@ func sendToPeers(conn net.Conn) {
 			}
 		}
 		fmt.Println("Finished copying!")
+		delete(tcpMap, peer.Friend)
+		delete(tcpMap, peer.Name)
 	} else {
 		fmt.Println("Recieved tcp connection from ", conn.RemoteAddr())
 		tcpMap[peer.Name] = conn


### PR DESCRIPTION
If both the local and public quic connections cannot be established, we should send through the server instead and notify the user.